### PR TITLE
Enable clearing all data from settings

### DIFF
--- a/dist-electron/main.js
+++ b/dist-electron/main.js
@@ -21857,6 +21857,11 @@ var utils = {
   sheet_to_json,
   sheet_to_html,
   sheet_to_formulae,
+async function resetDatabase() {
+  await db.read();
+  db.data = { ...defaultData };
+  await db.write();
+}
   sheet_to_row_object_array: sheet_to_json,
   sheet_get_cell: ws_get_cell_stub,
   book_new,
@@ -22202,6 +22207,15 @@ electron.ipcMain.handle("add-client", async (event, client) => await addClient(c
 electron.ipcMain.handle("update-client", async (event, { id, data }) => await updateClient(id, data));
 electron.ipcMain.handle("delete-client", async (event, id) => await deleteClient(id));
 electron.ipcMain.handle("get-products", async () => await getProducts());
+electron.ipcMain.handle("reset-database", async () => {
+  try {
+    await resetDatabase();
+    return { success: true, message: "Ma'lumotlar bazasi tozalandi" };
+  } catch (error) {
+    console.error(error);
+    return { success: false, message: error.message };
+  }
+});
 electron.ipcMain.handle("add-product", async (event, product) => await addProduct(product));
 electron.ipcMain.handle("update-product", async (event, { id, data }) => await updateProduct(id, data));
 electron.ipcMain.handle("delete-product", async (event, id) => await deleteProduct(id));

--- a/electron/database.ts
+++ b/electron/database.ts
@@ -26,6 +26,12 @@ const db = new Low(adapter, defaultData);
 
 export async function initializeDatabase() { await db.read(); db.data = { ...defaultData, ...db.data }; await db.write(); console.log(`✅ Ma'lumotlar bazasi muvaffaqiyatli ishga tushdi va yangilandi: ${dbPath}`); }
 
+export async function resetDatabase() {
+  await db.read();
+  db.data = { ...defaultData };
+  await db.write();
+}
+
 // Umumiy o'chirish funksiyasi
 async function deleteItemById<T extends { id: number }>(tableName: keyof Schema, id: number) {
   await db.read();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,7 +18,8 @@ import {
   getTransactions,
   getSalesReport,
   exportDataToExcel,
-  getTodaysFinancialSummary
+  getTodaysFinancialSummary,
+  resetDatabase
 } from './database';
 
 process.env.DIST = path.join(__dirname, '../dist');
@@ -86,6 +87,15 @@ ipcMain.handle('get-financial-summary', async () => await getFinancialSummary())
 ipcMain.handle('get-transactions', async (event, filters) => await getTransactions(filters));
 ipcMain.handle('get-sales-report', async (event, filters) => await getSalesReport(filters));
 ipcMain.handle('get-todays-financial-summary', async () => await getTodaysFinancialSummary());
+ipcMain.handle('reset-database', async () => {
+  try {
+    await resetDatabase();
+    return { success: true, message: "Ma'lumotlar bazasi tozalandi" };
+  } catch (error) {
+    console.error(error);
+    return { success: false, message: (error as Error).message };
+  }
+});
 ipcMain.handle('export-data', async () => {
   try {
     const buffer = await exportDataToExcel();


### PR DESCRIPTION
## Summary
- add LowDB reset helper to wipe application data
- handle `reset-database` IPC message in the Electron main process

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68afe4d390ac832580e8a42714ca2426