### PR TITLE
Enable clearing all data from settings

### DIFF
--- a/dist-electron/main.js
+++ b/dist-electron/main.js
@@ -21857,6 +21857,11 @@ var utils = {
   sheet_to_json,
   sheet_to_html,
   sheet_to_formulae,
+async function resetDatabase() {
+  await db.read();
+  db.data = { ...defaultData };
+  await db.write();
+}
   sheet_to_row_object_array: sheet_to_json,
   sheet_get_cell: ws_get_cell_stub,
   book_new,
@@ -22202,6 +22207,15 @@ electron.ipcMain.handle("add-client", async (event, client) => await addClient(c
 electron.ipcMain.handle("update-client", async (event, { id, data }) => await updateClient(id, data));
 electron.ipcMain.handle("delete-client", async (event, id) => await deleteClient(id));
 electron.ipcMain.handle("get-products", async () => await getProducts());
+electron.ipcMain.handle("reset-database", async () => {
+  try {
+    await resetDatabase();
+    return { success: true, message: "Ma'lumotlar bazasi tozalandi" };
+  } catch (error) {
+    console.error(error);
+    return { success: false, message: error.message };
+  }
+});
 electron.ipcMain.handle("add-product", async (event, product) => await addProduct(product));
 electron.ipcMain.handle("update-product", async (event, { id, data }) => await updateProduct(id, data));
 electron.ipcMain.handle("delete-product", async (event, id) => await deleteProduct(id));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,7 +18,9 @@ import {
   getTransactions,
   getSalesReport,
   exportDataToExcel,
-  getTodaysFinancialSummary
+  getDataForPeriod,
+  getTodaysFinancialSummary,
+  resetDatabase
 } from './database';
 
 process.env.DIST = path.join(__dirname, '../dist');
@@ -86,13 +88,54 @@ ipcMain.handle('get-financial-summary', async () => await getFinancialSummary())
 ipcMain.handle('get-transactions', async (event, filters) => await getTransactions(filters));
 ipcMain.handle('get-sales-report', async (event, filters) => await getSalesReport(filters));
 ipcMain.handle('get-todays-financial-summary', async () => await getTodaysFinancialSummary());
-ipcMain.handle('export-data', async () => {
+ipcMain.handle('reset-database', async () => {
   try {
-    const buffer = await exportDataToExcel();
+    await resetDatabase();
+    return { success: true, message: "Ma'lumotlar bazasi tozalandi" };
+  } catch (error) {
+    console.error(error);
+    return { success: false, message: (error as Error).message };
+  }
+});
+
+function generatePDFBuffer(content: string) {
+  const safe = content.replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+  const pdf = `%PDF-1.1\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n4 0 obj\n<< /Length ${safe.length + 33} >>\nstream\nBT /F1 12 Tf 72 720 Td (${safe}) Tj ET\nendstream\nendobj\n5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\nxref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000061 00000 n \n0000000116 00000 n \n0000000225 00000 n \n0000000334 00000 n \ntrailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n409\n%%EOF`;
+  return Buffer.from(pdf);
+}
+
+function generateWordBuffer(content: string) {
+  const html = `<html><head><meta charset="utf-8"></head><body><pre>${content}</pre></body></html>`;
+  return Buffer.from(html, 'utf-8');
+}
+
+ipcMain.handle('export-data', async (event, { format, period }) => {
+  try {
+    const data = await getDataForPeriod(period);
+    let buffer: Buffer;
+    let filters;
+    let ext;
+    if (format === 'excel') {
+      buffer = await exportDataToExcel(period);
+      filters = [{ name: 'Excel Files', extensions: ['xlsx'] }];
+      ext = 'xlsx';
+    } else {
+      const json = JSON.stringify(data, null, 2);
+      if (format === 'pdf') {
+        buffer = generatePDFBuffer(json);
+        filters = [{ name: 'PDF Files', extensions: ['pdf'] }];
+        ext = 'pdf';
+      } else {
+        buffer = generateWordBuffer(json);
+        filters = [{ name: 'Word Files', extensions: ['doc'] }];
+        ext = 'doc';
+      }
+    }
+
     const { filePath } = await dialog.showSaveDialog({
-      title: 'Excel faylni saqlash',
-      defaultPath: `hisobot-${new Date().toISOString().split('T')[0]}.xlsx`,
-      filters: [{ name: 'Excel Files', extensions: ['xlsx'] }]
+      title: 'Hisobotni saqlash',
+      defaultPath: `hisobot-${period}-${new Date().toISOString().split('T')[0]}.${ext}`,
+      filters,
     });
     if (filePath) {
       fs.writeFileSync(filePath, buffer);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -44,7 +44,8 @@ const api = {
   getTransactions: (filters: { startDate: string, endDate: string }) => ipcRenderer.invoke('get-transactions', filters),
   getSalesReport: (filters: { startDate: string, endDate: string }) => ipcRenderer.invoke('get-sales-report', filters),
   getTodaysFinancialSummary: () => ipcRenderer.invoke('get-todays-financial-summary'),
-  exportData: () => ipcRenderer.invoke('export-data'),
+  exportData: (format: 'excel' | 'pdf' | 'word', period: 'daily' | 'weekly' | 'monthly') =>
+    ipcRenderer.invoke('export-data', { format, period }),
 
   // Settings
   resetDatabase: () => ipcRenderer.invoke('reset-database'),

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -23,9 +23,11 @@ const Settings = () => {
     }
   };
 
-  const handleExportData = async () => {
+  const [period, setPeriod] = React.useState<'daily' | 'weekly' | 'monthly'>('daily');
+
+  const handleExportData = async (format: 'excel' | 'pdf' | 'word') => {
     try {
-      const result = await window.api.exportData();
+      const result = await window.api.exportData(format, period);
       if (result.success) {
         alert(`Ma'lumotlar muvaffaqiyatli saqlandi: ${result.path}`);
       } else {
@@ -44,14 +46,37 @@ const Settings = () => {
         <h2 className="text-xl font-semibold mb-4">Ma'lumotlarni Boshqarish</h2>
         <div className="space-y-4">
           <div>
-            <h3 className="text-lg font-medium">Ma'lumotlarni Excelga yuklash</h3>
-            <p className="text-gray-600 mt-1">Dasturdagi barcha ma'lumotlarni (mijozlar, savdolar, xarajatlar va h.k.) bitta Excel fayliga saqlab olish.</p>
-            <button 
-              onClick={handleExportData}
-              className="mt-2 bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors"
-            >
-              Excelga Yuklash
-            </button>
+            <h3 className="text-lg font-medium">Ma'lumotlarni Yuklab Olish</h3>
+            <p className="text-gray-600 mt-1">Ma'lumotlarni (mijozlar, savdolar, xarajatlar va h.k.) kunlik, haftalik yoki oylik kesimida yuklab olish.</p>
+            <div className="mt-2 flex items-center space-x-2">
+              <select
+                value={period}
+                onChange={(e) => setPeriod(e.target.value as any)}
+                className="border rounded-md px-2 py-1"
+              >
+                <option value="daily">Kunlik</option>
+                <option value="weekly">Haftalik</option>
+                <option value="monthly">Oylik</option>
+              </select>
+              <button
+                onClick={() => handleExportData('excel')}
+                className="bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors"
+              >
+                Excel
+              </button>
+              <button
+                onClick={() => handleExportData('pdf')}
+                className="bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors"
+              >
+                PDF
+              </button>
+              <button
+                onClick={() => handleExportData('word')}
+                className="bg-purple-600 text-white py-2 px-4 rounded-md hover:bg-purple-700 transition-colors"
+              >
+                Word
+              </button>
+            </div>
           </div>
           
           <div className="border-t pt-4">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -44,7 +44,10 @@ interface Window {
     getTransactions: (filters: { startDate: string; endDate: string; }) => Promise<{ date: string; type: string; description: string; amount: number; }[]>;
     getSalesReport: (filters: { startDate: string; endDate: string; }) => Promise<{ name: string; totalQuantity: number; totalAmount: number; }[]>;
     getTodaysFinancialSummary: () => Promise<{ todayCashIn: number; todayCashOut: number; todayKassa: number; }>;
-    exportData: () => Promise<{ success: boolean; path?: string; message?: string }>;
+    exportData: (
+      format: 'excel' | 'pdf' | 'word',
+      period: 'daily' | 'weekly' | 'monthly'
+    ) => Promise<{ success: boolean; path?: string; message?: string }>;
 
     // Settings
     resetDatabase: () => Promise<{ success: boolean; message?: string }>;


### PR DESCRIPTION
## Summary
- add LowDB reset helper to wipe application data
- handle `reset-database` IPC message in the Electron main process
- enable period-based export of data to Excel, PDF, and Word formats from settings

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afe4d390ac832580e8a42714ca2426