### PR TITLE
fix: ensure modals close cleanly

### DIFF
--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -39,12 +39,25 @@ const Clients = () => {
     setEditingClient(null);
   };
 
+  const closeModal = () => {
+    setIsModalOpen(false);
+    resetForm();
+  };
+
   useEffect(() => {
-    return () => {
-      setIsModalOpen(false);
-      resetForm();
-    };
+    return () => closeModal();
   }, []);
+
+  useEffect(() => {
+    if (isModalOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isModalOpen]);
 
   // Yangi mijoz qo'shish oynasini ochish
   const handleAddNew = () => {
@@ -91,8 +104,7 @@ const Clients = () => {
     }
     
     fetchClients();
-    setIsModalOpen(false);
-    resetForm();
+    closeModal();
   };
 
   return (
@@ -156,7 +168,7 @@ const Clients = () => {
                 <input type="number" value={initialDebt} onChange={(e) => setInitialDebt(e.target.value)} className="mt-1 p-2 border rounded-md w-full" />
               </div>
               <div className="flex justify-end gap-4 pt-4">
-                <button type="button" onClick={() => setIsModalOpen(false)} className="bg-gray-200 px-4 py-2 rounded-md hover:bg-gray-300">
+                <button type="button" onClick={closeModal} className="bg-gray-200 px-4 py-2 rounded-md hover:bg-gray-300">
                   Bekor qilish
                 </button>
                 <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700">

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -26,12 +26,25 @@ const Products = () => {
     setEditingProduct(null);
   };
 
+  const closeModal = () => {
+    setIsModalOpen(false);
+    resetForm();
+  };
+
   useEffect(() => {
-    return () => {
-      setIsModalOpen(false);
-      resetForm();
-    };
+    return () => closeModal();
   }, []);
+
+  useEffect(() => {
+    if (isModalOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isModalOpen]);
 
   const handleAddNew = () => {
     resetForm();
@@ -65,8 +78,7 @@ const Products = () => {
     }
     
     fetchProducts();
-    setIsModalOpen(false);
-    resetForm();
+    closeModal();
   };
 
   return (
@@ -104,7 +116,7 @@ const Products = () => {
                 />
               </div>
               <div className="flex justify-end gap-4 pt-4">
-                <button type="button" onClick={() => setIsModalOpen(false)} className="bg-gray-200 px-4 py-2 rounded-md hover:bg-gray-300">
+                <button type="button" onClick={closeModal} className="bg-gray-200 px-4 py-2 rounded-md hover:bg-gray-300">
                   Bekor qilish
                 </button>
                 <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700">


### PR DESCRIPTION
## Summary
- ensure Clients and Products modals reset state and body overflow when closing
- add reusable closeModal helper to avoid lingering overlays

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68affdeabbf08325a818d370b4e9a9a8